### PR TITLE
v1.42.0

### DIFF
--- a/recipe/0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
+++ b/recipe/0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
@@ -12,9 +12,9 @@ diff --git a/setup.py b/setup.py
 index ae86e6c9fb..86c765be20 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -119,6 +119,25 @@ ENABLE_CYTHON_TRACING = os.environ.get(
- ENABLE_DOCUMENTATION_BUILD = os.environ.get(
-     'GRPC_PYTHON_ENABLE_DOCUMENTATION_BUILD', False)
+@@ -124,6 +124,25 @@ class BuildExt(build_ext.build_ext):
+         return filename
+ 
  
 +# Patch ccompiler not to pass -std=c++11 for C code.
 +# This is neccessary on macOS to avoid:
@@ -38,15 +38,13 @@ index ae86e6c9fb..86c765be20 100644
  # There are some situations (like on Windows) where CC, CFLAGS, and LDFLAGS are
  # entirely ignored/dropped/forgotten by distutils and its Cygwin/MinGW support.
  # We use these environment variables to thus get around that without locking
-@@ -334,6 +353,8 @@ PACKAGE_DATA = {
- }
- PACKAGES = setuptools.find_packages(PYTHON_STEM)
+@@ -276,6 +295,7 @@ def extension_modules():
+     else:
+         return extensions
  
 +monkeypatch_spawn_using_cxx11_for_cxx_only()
-+
- setuptools.setup(
-   name='grpcio',
-   version=grpc_version.VERSION,
+ 
+ setuptools.setup(name='grpcio-tools',
+                  version=grpc_version.VERSION,
 -- 
 2.19.1
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,8 @@ source:
 
 build:
   number: 0
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - protobuf
+    - protobuf 3.19.1
     - python
   run:
     - grpcio =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ requirements:
   host:
     - grpcio =={{ version }}
     - pip
+    - setuptools
+    - wheel
     - protobuf >=3.6.0
     - python
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.35.0" %}
+{% set version = "1.42.0" %}
 {% set name = "grpcio-tools" %}
 
 package:
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9e2a41cba9c5a20ae299d0fdd377fe231434fa04cbfbfb3807293c6ec10b03cf
+  sha256: d0a0daa82eb2c2fb8e12b82a458d1b7c5516fe1135551da92b1a02e2cba93422
   patches:
     - 0001-Monkey-patch-distutils.ccompiler.spawn-to-elide-std-.patch
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -41,7 +41,7 @@ about:
   license_family: APACHE
   license_file: LICENSE.txt
   summary: Protobuf code generator for gRPC
-  doc_source_url: https://github.com/grpc/grpc/tree/master/doc
+  description: Various tools for use with gRPC
   doc_url: https://grpc.io/docs/
   dev_url: https://github.com/grpc/grpc/tree/master/tools
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - protobuf >=3.6.0
+    - protobuf
     - python
   run:
     - grpcio =={{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,12 @@ requirements:
     - python
 
 test:
+  requires:
+    - pip
   imports:
     - grpc_tools
+  commands:
+    - pip check
 
 about:
   home: https://grpc.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - protobuf 3.19.1
+    - protobuf 3.20.3
     - python
   run:
     - grpcio =={{ version }}


### PR DESCRIPTION
# grpcio-tools v1.42.0

- Update to match current grpio-feedstock version on defaults

## Changes
- Update version and SHA
- Reset build number
- Add setuptools + wheel dependencies
- Add pip check

## Notes
- This is needed for python 3.11 buildout